### PR TITLE
fix: Pin gitleaks pre-commit hook to commit SHA instead of tag

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.30.0
+    rev: 6eaad039603a4de39fddd1cf5f727391efe9974e  # v8.30.0
     hooks:
       - id: gitleaks

--- a/SKILL.md
+++ b/SKILL.md
@@ -163,7 +163,7 @@ Before running, verify in order. Fail fast — stop on first failure with action
         ```yaml
         repos:
           - repo: https://github.com/gitleaks/gitleaks
-            rev: v8.30.0
+            rev: 6eaad039603a4de39fddd1cf5f727391efe9974e  # v8.30.0
             hooks:
               - id: gitleaks
         ```


### PR DESCRIPTION
## Summary

- Pin gitleaks pre-commit hook to full commit SHA (`6eaad039603a4de39fddd1cf5f727391efe9974e`) instead of git tag (`v8.30.0`) for supply chain hardening
- Updated both `SKILL.md` (wf-setup template) and `.pre-commit-config.yaml`
- Retained `# v8.30.0` comment for human readability

Closes #5

## Testing

- Pre-commit hook ran successfully on the commit itself (gitleaks detected the new SHA and installed correctly)
- Verified SHA matches the dereferenced tag via `git ls-remote`

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)