### PR TITLE
fix: Clarify baseline scoping wording in security review spec

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -449,7 +449,7 @@ Check required tools per platform. If missing, ask permission to install:
 
 ### Scan Steps
 
-1. **Run scans** (parallel where possible, scoped to PR diff via `--baseline-commit`):
+1. **Run scans** (parallel where possible, semgrep scoped to PR diff via `--baseline-commit`; other tools scan full codebase):
 
    PHP/Laravel/WordPress:
    ```bash


### PR DESCRIPTION
## Summary

- Clarified that only semgrep is scoped to PR diff via `--baseline-commit`
- Other tools (phpstan, govulncheck, gosec, composer audit) scan the full codebase
- Single-line wording fix in SKILL.md

Closes #6

## Testing

- Verified the updated line reads correctly and accurately reflects tool capabilities

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)